### PR TITLE
Fix Dupe Glitch & Update pom.xml

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -23,12 +23,12 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>mvdw-software</id>
             <name>MVdW Public Repositories</name>
-            <url>http://repo.mvdw-software.be/content/groups/public/</url>
+            <url>https://repo.mvdw-software.com/content/groups/public/</url>
         </repository>
         <repository>
             <id>codemc-repo</id>
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>be.maximvdw</groupId>
             <artifactId>MVdWPlaceholderAPI</artifactId>
-            <version>2.5.2-SNAPSHOT</version>
+            <version>3.1.1-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/plugin/src/main/java/me/badbones69/crazycrates/Methods.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/Methods.java
@@ -175,9 +175,11 @@ public class Methods {
     }
     
     public static boolean isSimilar(ItemStack itemStack, Crate crate) {
+        NBTItem nbtItem = new NBTItem(itemStack);
+
         return itemStack.isSimilar(crate.getKey()) || itemStack.isSimilar(crate.getKeyNoNBT()) ||
         itemStack.isSimilar(crate.getAdminKey()) || stripNBT(itemStack).isSimilar(crate.getKeyNoNBT()) ||
-        isSimilarCustom(crate.getKeyNoNBT(), itemStack);
+        isSimilarCustom(crate.getKeyNoNBT(), itemStack) || (nbtItem.hasKey("CrazyCrates-Crate") && crate.getName().equals(nbtItem.getString("CrazyCrates-Crate")));
     }
     
     private static boolean isSimilarCustom(ItemStack one, ItemStack two) {

--- a/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -1042,6 +1042,7 @@ public class CrazyCrates {
      */
     public ItemStack getPhysicalKey(Player player, Crate crate) {
         for (ItemStack item : player.getOpenInventory().getBottomInventory().getContents()) {
+            if(item == null || item.getType() == Material.AIR) continue;
             if (Methods.isSimilar(item, crate)) {
                 return item;
             }
@@ -1101,10 +1102,9 @@ public class CrazyCrates {
     public int getPhysicalKeys(Player player, Crate crate) {
         int keys = 0;
         for (ItemStack item : player.getOpenInventory().getBottomInventory().getContents()) {
-            if (item != null) {
-                if (Methods.isSimilar(item, crate)) {
-                    keys += item.getAmount();
-                }
+            if (item == null || item.getType() == Material.AIR) continue;
+            if (Methods.isSimilar(item, crate)) {
+                keys += item.getAmount();
             }
         }
         return keys;

--- a/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -1104,13 +1104,6 @@ public class CrazyCrates {
             if (item != null) {
                 if (Methods.isSimilar(item, crate)) {
                     keys += item.getAmount();
-                } else {
-                    NBTItem nbtItem = new NBTItem(item);
-                    if (nbtItem.hasKey("CrazyCrates-Crate")) {
-                        if (crate.getName().equals(nbtItem.getString("CrazyCrates-Crate"))) {
-                            keys += item.getAmount();
-                        }
-                    }
                 }
             }
         }

--- a/plugin/src/main/java/me/badbones69/crazycrates/cratetypes/CrateOnTheGo.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/cratetypes/CrateOnTheGo.java
@@ -7,6 +7,7 @@ import me.badbones69.crazycrates.api.events.PlayerPrizeEvent;
 import me.badbones69.crazycrates.api.objects.Crate;
 import me.badbones69.crazycrates.api.objects.Prize;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -23,23 +24,23 @@ public class CrateOnTheGo implements Listener {
         Player player = e.getPlayer();
         if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
             ItemStack item = cc.getNMSSupport().getItemInMainHand(player);
-            if (item != null) {
-                for (Crate crate : cc.getCrates()) {
-                    if (crate.getCrateType() == CrateType.CRATE_ON_THE_GO && Methods.isSimilar(item, crate)) {
-                        e.setCancelled(true);
-                        cc.addPlayerToOpeningList(player, crate);
-                        Methods.removeItem(item, player);
-                        Prize prize = crate.pickPrize(player);
-                        cc.givePrize(player, prize);
-                        Bukkit.getPluginManager().callEvent(new PlayerPrizeEvent(player, crate, cc.getOpeningCrate(player).getName(), prize));
-                        if (prize.useFireworks()) {
-                            Methods.fireWork(player.getLocation().add(0, 1, 0));
-                        }
-                        cc.removePlayerFromOpeningList(player);
+
+            if (item == null || item.getType() == Material.AIR) return;
+
+            for (Crate crate : cc.getCrates()) {
+                if (crate.getCrateType() == CrateType.CRATE_ON_THE_GO && Methods.isSimilar(item, crate)) {
+                    e.setCancelled(true);
+                    cc.addPlayerToOpeningList(player, crate);
+                    Methods.removeItem(item, player);
+                    Prize prize = crate.pickPrize(player);
+                    cc.givePrize(player, prize);
+                    Bukkit.getPluginManager().callEvent(new PlayerPrizeEvent(player, crate, cc.getOpeningCrate(player).getName(), prize));
+                    if (prize.useFireworks()) {
+                        Methods.fireWork(player.getLocation().add(0, 1, 0));
                     }
+                    cc.removePlayerFromOpeningList(player);
                 }
             }
         }
     }
-    
 }

--- a/plugin/src/main/java/me/badbones69/crazycrates/cratetypes/QuickCrate.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/cratetypes/QuickCrate.java
@@ -34,7 +34,7 @@ public class QuickCrate implements Listener {
     private static HashMap<Player, BukkitTask> tasks = new HashMap<>();
     
     public static void openCrate(final Player player, final Location loc, Crate crate, KeyType keyType) {
-        int keys;// If the key is free it is set to one.
+        int keys; // If the key is free it is set to one.
         switch (keyType) {
             case VIRTUAL_KEY:
                 keys = cc.getVirtualKeys(player, crate);
@@ -46,21 +46,24 @@ public class QuickCrate implements Listener {
                 keys = 1;
                 break;
         }
+
         if (player.isSneaking() && keys > 1) {
             int keysUsed = 0;
-            for (; keys > 0; keys--) {
-                if (!Methods.isInventoryFull(player)) {
-                    Prize prize = crate.pickPrize(player);
-                    cc.givePrize(player, prize);
-                    Bukkit.getPluginManager().callEvent(new PlayerPrizeEvent(player, crate, crate.getName(), prize));
-                    if (prize.useFireworks()) {
-                        Methods.fireWork(loc.clone().add(.5, 1, .5));
-                    }
-                    keysUsed++;
-                } else {
-                    break;
+
+            // give the player the prizes
+            for(; keys > 0; keys--) {
+                if(Methods.isInventoryFull(player)) break;
+
+                Prize prize = crate.pickPrize(player);
+                cc.givePrize(player, prize);
+                Bukkit.getPluginManager().callEvent(new PlayerPrizeEvent(player, crate, crate.getName(), prize));
+                if (prize.useFireworks()) {
+                    Methods.fireWork(loc.clone().add(.5, 1, .5));
                 }
+
+                keysUsed++;
             }
+
             if (!cc.takeKeys(keysUsed, player, crate, keyType, false)) {
                 Methods.failedToTakeKey(player, crate);
                 CrateControl.inUse.remove(player);


### PR DESCRIPTION
Fixes #381 by modifying the isSimilar method to include a check for NBT data, which was previously not there. Now, if they rename their item or modify the item's lore, it will still count as that type of key and will be used when a play shifts + right-clicks a quick crate. As far as my testing, this does not break any other types of crates, although testing was somewhat limited.

I also updated the plugin pom.xml to use the updated repositories for PlaceholderAPI & MVdWPlaceholderAPI, as well as the updated versions. I don't believe this will cause any issues.