### PR TITLE
Fixes /giveall With CrateOnTheGo

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -1225,7 +1225,7 @@ public class CrazyCrates {
         switch (keyType) {
             case PHYSICAL_KEY:
                 if (Methods.isInventoryFull(player)) {
-                    if (giveVirtualKeysWhenInventoryFull) {
+                    if (giveVirtualKeysWhenInventoryFull && crate.getCrateType() != CrateType.CRATE_ON_THE_GO) {
                         addKeys(amount, player, crate, KeyType.VIRTUAL_KEY);
                     } else {
                         player.getWorld().dropItem(player.getLocation(), crate.getKey(amount));

--- a/plugin/src/main/java/me/badbones69/crazycrates/commands/CCCommand.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/commands/CCCommand.java
@@ -548,10 +548,12 @@ public class CCCommand implements CommandExecutor {
                                 Bukkit.getPluginManager().callEvent(event);
                                 if (!event.isCancelled()) {
                                     player.sendMessage(Messages.OBTAINING_KEYS.getMessage(placeholders));
+
                                     if (crate.getCrateType() == CrateType.CRATE_ON_THE_GO) {
-                                        player.getInventory().addItem(crate.getKey(amount));
+                                        cc.addKeys(amount, player, crate, KeyType.PHYSICAL_KEY);
                                         return true;
                                     }
+
                                     cc.addKeys(amount, player, crate, type);
                                 }
                             }


### PR DESCRIPTION
This fixes #349 by adding a check to both the addKeys method as well as the /giveall command to ensure that every player is given X amount of CrateOnTheGo keys and also makes sure to drop those keys on the ground if a certain player's inventory was full. 

Further testing appears to work on the latest version (1.18.1).