### PR TITLE
allow pickup while opening quickcrates

### DIFF
--- a/plugin/src/main/java/com/badbones69/crazycrates/func/listeners/BasicListener.kt
+++ b/plugin/src/main/java/com/badbones69/crazycrates/func/listeners/BasicListener.kt
@@ -1,6 +1,7 @@
 package com.badbones69.crazycrates.func.listeners
 
 import com.badbones69.crazycrates.api.CrazyManager
+import com.badbones69.crazycrates.api.enums.CrateType
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -13,7 +14,10 @@ class BasicListener : Listener {
         if (CrazyManager.getInstance().isDisplayReward(item)) isCancelled = true else {
             if (entity !is Player) return
             val player = entity as Player
-            if (CrazyManager.getInstance().isInOpeningList(player)) isCancelled = true
+            if (CrazyManager.getInstance().isInOpeningList(player)) {
+                if (CrazyManager.getInstance().getOpeningCrate(player).crateType.equals(CrateType.QUICK_CRATE)) return
+                isCancelled = true
+            }
         }
     }
 }


### PR DESCRIPTION
Some plugins such as InvisibleItemFrames give items to players in a way that requires players to pick up the item from the ground. Currently, CC prevents players from picking up items while opening crates. As a consequence, players on my server who win invisible item frames from quickcrates do not get the item frames they deserve. Instead, these item frames are picked up by other players and cause the deserving player to think the crates are broken. 

From my understanding after a discussion with Ryder is that [the line](https://github.com/Crazy-Crew/Crazy-Crates/blob/5a0d5c1a979459f34feb4bc353ccf4ab2307ec57/plugin/src/main/java/com/badbones69/crazycrates/func/listeners/BasicListener.kt#L16), which players who are opening crates from picking up items, has two main purposes: 
1. Make it so players still have an empty spot in their inventory until they receive their item from the crate.
2. Act as a failsafe for line 13 which prevents people from picking up the display item on the quickcrate.

Purpose 1 is not needed for quickcrates as the prizes are given instantly. Since this line is causing problems for myself and possibly others, and since purpose 2 is already accomplished through line 13 in a more complete way, I would like to allow players who are opening quickcrates to be able to do so.

I have tested this build on my own server and found that it does indeed fix my issue and still prevents players from picking up the display item on the quickcrate.